### PR TITLE
Windows: Keep HOME and APPDATA

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -250,6 +250,17 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		if ( false !== $github_token ) {
 			$env['GITHUB_TOKEN'] = $github_token;
 		}
+
+		$home = getenv( 'HOME' );
+		if ( false !== $home ) {
+			$env['HOME'] = $home;
+		}
+
+		$appdata = getenv( 'APPDATA' );
+		if ( false !== $appdata ) {
+			$env['APPDATA'] = $appdata;
+		}
+
 		return $env;
 	}
 

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -778,7 +778,8 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	 * Remove a directory (recursive).
 	 */
 	public static function remove_dir( $dir ) {
-		Process::create( Utils\esc_cmd( 'rm -rf %s', $dir ) )->run_check();
+		$rmdir = (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') ? 'rmdir /Q /S' : 'rm -rf';
+		Process::create( Utils\esc_cmd( "${rmdir} %s", $dir ) )->run_check();
 	}
 
 	/**


### PR DESCRIPTION
Windows needs home to not make temp `C:\WINDOWS`

It also needs `APPDATA` for composer without `COMPOSER_HOME` set explicitly in the `ENV`

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
